### PR TITLE
Add config.js to .gitignore, fix run script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
 data/config.js
-src/config.js
 node_modules/
 package-lock.json
-src/node_modules/
-src/package-lock.json
 *.swp

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+data/config.js
 src/config.js
 node_modules/
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "scripts/bot.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node hopson_bot/hopson_bot.js"
+    "start": "node src/hopson_bot.js"
   },
   "repository": {
     "type": "git",

--- a/run.bat
+++ b/run.bat
@@ -1,2 +1,2 @@
-node src/hopson_bot.js
+npm start
 pause


### PR DESCRIPTION
Ensures key is not accidentally added to repo.

Changed run script to call `npm start`, in future only the "start" script in `package.json` will need to be changed if directories are restructured.