### PR TITLE
Fix length bug when querying the CPP reference with too many results

### DIFF
--- a/src/commands/ref_command_handler.js
+++ b/src/commands/ref_command_handler.js
@@ -17,8 +17,9 @@ module.exports = class ReferenceCommandHandler extends CommandHandler {
 
 function cppReference(message, args) {
     const channel = message.channel;
-    if (args.length < 1)
+    if (args.length < 1) {
         return;
+    }
 
     request("https://en.cppreference.com/w/cpp/header")
         .then((html) => {
@@ -42,15 +43,15 @@ function cppReference(message, args) {
             }
 			
             if (results.length > 0) {
-				var l = 0;
-				for (var i = 0; i < results.length; i++)
-					l += results[i].length;
-				
-				if (l < 2000) {
-					channel.send(results);
-				} else {
-					channel.send("Well, those were too many results! Try making your query a bit more specific...");
-				}
+                var stringLength = 0;
+                for (var str of results)
+                    stringLength += str.length;
+		
+                if (l < 2000) {
+                    channel.send(results);
+                } else {
+                    channel.send("Well, those were too many results! Try making your query a bit more specific...");
+                }
             }
             else {
                 channel.send(`I cannot find anything in C++ with ${args[0]}`);

--- a/src/commands/ref_command_handler.js
+++ b/src/commands/ref_command_handler.js
@@ -43,26 +43,29 @@ function cppReference(message, args) {
             }
 			
             if (results.length > 0) {
-                var errorMessage = "There are too many results, please use a more specific query";
-                var stringLength = 0;
-                var msg = `Results found for ${args[0]}:\n`;
-                for (var str of results) {
-                    stringLength += str.length;
+                let msg = {embed: {
+                    title: `Results found for ${args[0]}:\n`,
+                    color: 3447003,
+                    fields: []
+                }};
 
+                for (const result of results) {
                     //We implement the limit INSIDE the loop, and break if we are done, so we don't have to loop
                     //over protentially hundreds of results if we're already out of the limit
-                    if (stringLength > 2000) {
-                        msg = {embed: {
-                            color: 16525315,
-                            fields: [{
-                                name: "Error",
-                                value: errorMessage
-                            }]
-                        }};
+                    if (msg.embed.fields.length >= 24) {
+                        msg.embed.fields.push({
+                            name: ":warning: Error",
+                            value: "There are too many results to display them all, please use a more specific query"
+                        });
+                        msg.embed.color = 15452468;
                         break;
                     }
 
-                    msg += str + "\n";
+                    msg.embed.fields.push({
+                        name: "#" + (msg.embed.fields.length + 1),
+                        value: result,
+                        inline: true
+                    });
                 }
 
                 channel.send(msg);

--- a/src/commands/ref_command_handler.js
+++ b/src/commands/ref_command_handler.js
@@ -47,7 +47,7 @@ function cppReference(message, args) {
                 for (var str of results)
                     stringLength += str.length;
 		
-                if (l < 2000) {
+                if (stringLength < 2000) {
                     channel.send(results);
                 } else {
                     channel.send("Well, those were too many results! Try making your query a bit more specific...");

--- a/src/commands/ref_command_handler.js
+++ b/src/commands/ref_command_handler.js
@@ -17,9 +17,8 @@ module.exports = class ReferenceCommandHandler extends CommandHandler {
 
 function cppReference(message, args) {
     const channel = message.channel;
-    if (args.length < 1) {
+    if (args.length < 1)
         return;
-    }
 
     request("https://en.cppreference.com/w/cpp/header")
         .then((html) => {
@@ -34,7 +33,6 @@ function cppReference(message, args) {
                 }
             }
 
-
             const results = [];
             for (const ref of hrefs) {
                 if (ref.search(args[0]) > 0) {
@@ -42,8 +40,17 @@ function cppReference(message, args) {
                     results.push("https://en.cppreference.com/" + ref);
                 }
             }
+			
             if (results.length > 0) {
-                channel.send(results);
+				var l = 0;
+				for (var i = 0; i < results.length; i++)
+					l += results[i].length;
+				
+				if (l < 2000) {
+					channel.send(results);
+				} else {
+					channel.send("Well, those were too many results! Try making your query a bit more specific...");
+				}
             }
             else {
                 channel.send(`I cannot find anything in C++ with ${args[0]}`);

--- a/src/commands/ref_command_handler.js
+++ b/src/commands/ref_command_handler.js
@@ -43,18 +43,38 @@ function cppReference(message, args) {
             }
 			
             if (results.length > 0) {
+                var errorMessage = "There are too many results, please use a more specific query";
                 var stringLength = 0;
-                for (var str of results)
+                var msg = `Results found for ${args[0]}:\n`;
+                for (var str of results) {
                     stringLength += str.length;
-		
-                if (stringLength < 2000) {
-                    channel.send(results);
-                } else {
-                    channel.send("Well, those were too many results! Try making your query a bit more specific...");
+
+                    //We implement the limit INSIDE the loop, and break if we are done, so we don't have to loop
+                    //over protentially hundreds of results if we're already out of the limit
+                    if (stringLength > 2000) {
+                        msg = {embed: {
+                            color: 16525315,
+                            fields: [{
+                                name: "Error",
+                                value: errorMessage
+                            }]
+                        }};
+                        break;
+                    }
+
+                    msg += str + "\n";
                 }
+
+                channel.send(msg);
             }
             else {
-                channel.send(`I cannot find anything in C++ with ${args[0]}`);
+                channel.send({embed: {
+                    color: 16525315,
+                    fields: [{
+                        name: "Error",
+                        value: `I cannot find anything in C++ with ${args[0]}`
+                    }]
+                }});
             }
     })
     .catch((error) => {


### PR DESCRIPTION
For now, the program just continues nicely, but this is deprecated, and eventually, when discord.js updates (likely near 2020) it will terminate the bot with a non-zero exit code. That's bad, because it makes it easy to crsah the bot.