### PR TITLE
Don't give introduced role when message is sent

### DIFF
--- a/src/events/message_sent_handler.js
+++ b/src/events/message_sent_handler.js
@@ -49,7 +49,7 @@ module.exports = class MessageSentHandler {
             let newMemberRole = message.member.guild.roles.find('name', Config.newMemberRole);
             let introduceRole = message.member.guild.roles.find('name', Config.introRole);
             message.member.removeRole(newMemberRole);
-            message.member.addRole(introduceRole);
+            //message.member.addRole(introduceRole);
             return;
         }
 


### PR DESCRIPTION
This is the only piece of code that gives the introduced role.
This means that a join message technically counts as a message sent and gives the role automatically.